### PR TITLE
Handle presidio whitespace

### DIFF
--- a/idscrub/scrub.py
+++ b/idscrub/scrub.py
@@ -634,7 +634,7 @@ class IDScrub:
         """
 
         nlp = self.get_spacy_model(model_name)
-        stripped_texts = [s.strip() if s.isspace() else s for s in texts]
+        stripped_texts = ["" if s.strip() == "" else s for s in texts]
         docs = nlp.pipe(stripped_texts, n_process=n_process, batch_size=batch_size)
 
         idents = []
@@ -825,9 +825,11 @@ class IDScrub:
 
         analyzer = AnalyzerEngine(nlp_engine=loaded_nlp_engine)
 
+        stripped_texts = ["" if s.strip() == "" else s for s in texts]
+
         idents = []
 
-        for text, text_id in zip(texts, text_ids):
+        for text, text_id in zip(stripped_texts, text_ids):
             results = analyzer.analyze(text=text, language="en", entities=entity_types)
             for res in results:
                 if res.entity_type not in entity_types:

--- a/test/test_presidio.py
+++ b/test/test_presidio.py
@@ -49,3 +49,11 @@ def test_presidio_get_data():
     )
 
     assert_frame_equal(df, expected_df)
+
+
+def test_presidio_empty():
+    scrub = IDScrub([" ", "  John Smith", ""])
+    scrubbed = scrub.scrub(pipeline=[{"method": "presidio_entities", "entity_types": ["PERSON"]}])
+
+    assert scrubbed == [" ", "  [PERSON]", ""]
+    assert_frame_equal(scrub.get_scrubbed_data(), pd.DataFrame({"text_id": 2, "person": [["John Smith"]]}))

--- a/test/test_spacy.py
+++ b/test/test_spacy.py
@@ -18,10 +18,10 @@ def test_spacy_error():
 
 
 def test_spacy_empty():
-    scrub = IDScrub([" ", "John Smith", ""])
+    scrub = IDScrub([" ", "  John Smith", ""])
     scrubbed = scrub.scrub(pipeline=[{"method": "spacy_entities"}])
 
-    assert scrubbed == [" ", "[PERSON]", ""]
+    assert scrubbed == [" ", "  [PERSON]", ""]
     assert_frame_equal(scrub.get_scrubbed_data(), pd.DataFrame({"text_id": 2, "person": [["John Smith"]]}))
 
 


### PR DESCRIPTION
Signed-off-by: DBT pre-commit check

## What

- Presidio breaks if a string of whitespace is passed

## Why

- Strip whitespace from these strings to avoid break

## How this has been tested

- [x] I have tested locally
- [x] I have added a new unit test (if appropriate)
- [ ] Testing not required

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present